### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.15.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Build and archive
       run: |
         GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
